### PR TITLE
Added new version specific mapping files ES

### DIFF
--- a/output/mistral_elasticsearch/PACKAGE
+++ b/output/mistral_elasticsearch/PACKAGE
@@ -1,3 +1,5 @@
 readme.rst
-schema/mappings.json
+schema/mappings_2.x.json
+schema/mappings_5.x.json
+schema/mappings_6.x.json
 schema/mistral_create_elastic_template.sh


### PR DESCRIPTION
Just tried to build the Mistral plug-ins (after several failed atempts locally I finally saw the ``package-plugins.sh`` script) and there was a warning ```tar: schema/mappings.json: Cannot stat: No such file or directory``` - the file has been replaced by multiple different versions in the elastic search plug-in - so this just changes the PACKAGE to reflect this.

- [x] Development complete
- [ ] Documentation complete
- [ ] Test case added
- [ ] Release notes updated
- [ ] Representative testing complete
- [ ] Full testing complete

**Reviewers:** 


**Target Review by date:** dd/mm/yyyy


